### PR TITLE
Changes LoadFile to LoadFrom to load DLLs included by plugins

### DIFF
--- a/src/workspacer/Plugins/PluginManager.cs
+++ b/src/workspacer/Plugins/PluginManager.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace workspacer
 {
@@ -52,8 +50,7 @@ namespace workspacer
             var name = new DirectoryInfo(dir).Name;
 
             Console.WriteLine(Path.Combine(dir, name + ".dll"));
-            var assembly = Assembly.LoadFile(Path.Combine(dir, name + ".dll"));
-
+            var assembly = Assembly.LoadFrom(Path.Combine(dir, name + ".dll"));
             var types = assembly.GetTypes().Where(t => typeof(IPlugin).IsAssignableFrom(t)).ToList();
 
             if (types.Count != 1)

--- a/src/workspacer/Workspacer.cs
+++ b/src/workspacer/Workspacer.cs
@@ -109,7 +109,7 @@ namespace workspacer
             var match = _context.Plugins.AvailablePlugins.Select(p => p.Assembly).SingleOrDefault(a => a.GetName().FullName == args.Name);
             if (match != null)
             {
-                return Assembly.LoadFile(match.Location);
+                return Assembly.LoadFrom(match.Location);
             }
             return null;
         }


### PR DESCRIPTION
Was discovered during development of Sound plugin as it loads other dll's to interface with native calls 